### PR TITLE
Fix typo in plugin `config.resolve` string

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package is a mod of [gatsby-transformer-remark](https://www.npmjs.com/packa
 // In your gatsby-config.js
 plugins: [
   {
-    resolve: `gatsby-transformer-remark`,
+    resolve: `gatsby-transformer-remark-rehype`,
     options: {
       // Footnotes mode (default: true)
       footnotes: true,


### PR DESCRIPTION
I guess it's a tiny typo since it's the name of the original plugin.

Thanks for the package!